### PR TITLE
Suggest commands based on usage history

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -19,6 +19,7 @@ When enabled, the app records simple usage counts in `localStorage` on the clien
   - `go:KEY` — opening a `go/KEY`
   - `go-search:QUERY` — selecting a dynamic `go/` search suggestion
   - `search:google` — submitting the Google form
+  - `cmd:TEXT` — executing a command via the Command DSL (e.g., `cmd:r/unixporn`)
 
 Example value:
 
@@ -27,7 +28,8 @@ Example value:
   "link:Tickets": 12,
   "go:PAM": 8,
   "go-search:datacenter": 3,
-  "search:google": 19
+  "search:google": 19,
+  "cmd:r/unixporn": 7
 }
 ```
 
@@ -35,6 +37,7 @@ Example value:
 
 - The Quick Launcher adds a small score boost based on these counts (capped)
 - Popular items surface higher in results over time
+- Frequently used command texts are suggested when typing partial matches, allowing quick re-run of past commands (e.g., type "unix" to see `Run again: r/unixporn`)
 
 ## Resetting counts
 


### PR DESCRIPTION
Implement learned command suggestions in Quick Launcher to recall frequently used DSL commands like `r/unixporn` from partial input.

---
<a href="https://cursor.com/background-agent?bcId=bc-522f6eb3-4d21-48c6-884e-7836ee7376e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-522f6eb3-4d21-48c6-884e-7836ee7376e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Quick Launcher now surfaces learned command suggestions based on your past usage, shown at the top of results.
  * Enter key fallback: if a direct command can’t be parsed, the top learned suggestion is executed automatically (Shift behavior respected).
  * Suggestions are ranked by match quality and frequency of use.

* Documentation
  * Updated analytics docs to include command execution counters and note that frequently used commands may be suggested during partial matches, with examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->