### PR TITLE
feat(dsl): updated the matcher so the last placeholder captures the r…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -70,17 +70,33 @@
 
   function matchPattern(pattern: string, inputTokens: string[]) {
     const pTokens = tokenizeCommand(pattern);
-    if (pTokens.length > inputTokens.length) return { ok: false };
+    if (inputTokens.length < pTokens.length) return { ok: false };
     
     const vars: any = {};
+    let consumedTokens = 0;
     for (let j = 0; j < pTokens.length; j++) {
-      const regex = buildTokenRegexFromPatternToken(pTokens[j]);
-      const m2 = inputTokens[j].match(regex);
-      if (!m2) return { ok: false };
-      const varNames2 = (pTokens[j].match(/\{([^}]+)\}/g) || []).map(x => x.slice(1, -1).trim());
-      for (let k2 = 0; k2 < varNames2.length; k2++) vars[varNames2[k2]] = m2[k2 + 1];
+      const patternTok = pTokens[j];
+      const isLast = j === pTokens.length - 1;
+      const regex = buildTokenRegexFromPatternToken(patternTok);
+      
+      if (isLast && inputTokens.length > pTokens.length) {
+        // Last placeholder can capture the rest of the input (including spaces)
+        const tail = inputTokens.slice(j).join(' ');
+        const m2 = tail.match(regex);
+        if (!m2) return { ok: false };
+        const varNames2 = (patternTok.match(/\{([^}]+)\}/g) || []).map(x => x.slice(1, -1).trim());
+        for (let k2 = 0; k2 < varNames2.length; k2++) vars[varNames2[k2]] = m2[k2 + 1];
+        consumedTokens = inputTokens.length;
+        break;
+      } else {
+        const m2 = inputTokens[j].match(regex);
+        if (!m2) return { ok: false };
+        const varNames2 = (patternTok.match(/\{([^}]+)\}/g) || []).map(x => x.slice(1, -1).trim());
+        for (let k2 = 0; k2 < varNames2.length; k2++) vars[varNames2[k2]] = m2[k2 + 1];
+      }
     }
-    return { ok: true, vars: vars, usedTokens: pTokens.length };
+    if (!consumedTokens) consumedTokens = pTokens.length;
+    return { ok: true, vars: vars, usedTokens: consumedTokens };
   }
 
   function parseCommandSegment(segment: string, cfg: any) {


### PR DESCRIPTION
This pull request updates the command pattern matching logic to better handle cases where the input contains extra tokens beyond the pattern length, specifically allowing the last placeholder in a pattern to capture the rest of the input. This change improves flexibility and correctness in command parsing.

### Enhancements to command pattern matching

* Updated the `matchPattern` function in both `app.js` and `src/app.ts` so that if the input contains more tokens than the pattern, the last placeholder can capture all remaining input tokens, including spaces. This enables commands with variable-length trailing arguments to be parsed correctly. [[1]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL73-R104) [[2]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bL73-R99)
* Adjusted the logic to track the number of tokens consumed, ensuring the returned value accurately reflects the tokens used during matching. [[1]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL73-R104) [[2]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bL73-R99)
* Improved variable extraction by ensuring the last placeholder's regex is applied to the joined tail of the input tokens, and variable names are parsed from the correct pattern token. [[1]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL73-R104) [[2]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bL73-R99)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Final placeholders now capture the remainder of the input, enabling multi-word arguments at the end of a command.
  * More accurate token usage reporting aligns with what was actually parsed.
  * Improved parsing reliability for commands with extra trailing words, reducing false mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->